### PR TITLE
made tidy df optional, default

### DIFF
--- a/man/pcr_lm.Rd
+++ b/man/pcr_lm.Rd
@@ -5,7 +5,7 @@
 \title{Linear regression qPCR data}
 \usage{
 pcr_lm(df, group_var, reference_gene, reference_group, model_matrix = NULL,
-  mode = "subtract", ...)
+  mode = "subtract", tidy = TRUE, ...)
 }
 \arguments{
 \item{df}{A data.frame of \eqn{C_T} values with genes in the columns and samples
@@ -25,6 +25,9 @@ constructing such a matrix with different variables check
 \item{mode}{A character string for the normalization mode. Possible values
 are "subtract" (default) or "divide".}
 
+\item{tidy}{A \code{logical} whether to return a \code{list} of
+\code{\link[stats]{lm}} or a tidy \code{data.frame}. Default TRUE.}
+
 \item{...}{Other arguments to \code{\link[stats]{lm}}}
 }
 \value{
@@ -37,6 +40,8 @@ A data.frame of 6 columns
   \item lower The low 95\% confidence interval
   \item upper The high 95\% confidence interval
 }
+When \code{tidy} is FALSE, returns a \code{list} of \code{\link[stats]{lm}}
+objects.
 }
 \description{
 Linear regression qPCR data

--- a/man/pcr_ttest.Rd
+++ b/man/pcr_ttest.Rd
@@ -4,7 +4,7 @@
 \alias{pcr_ttest}
 \title{t-test qPCR data}
 \usage{
-pcr_ttest(df, group_var, reference_gene, reference_group, ...)
+pcr_ttest(df, group_var, reference_gene, reference_group, tidy = TRUE, ...)
 }
 \arguments{
 \item{df}{A data.frame of \eqn{C_T} values with genes in the columns and samples
@@ -17,6 +17,9 @@ this variable should equal the number of rows of df}
 
 \item{reference_group}{A character string of the control group in group_var}
 
+\item{tidy}{A \code{logical} whether to return a \code{list} of \code{htest}
+or a tidy \code{data.frame}. Default TRUE.}
+
 \item{...}{Other arguments to \code{\link[stats]{t.test}}}
 }
 \value{
@@ -28,6 +31,7 @@ A data.frame of 5 columns
   \item lower The low 95\% confidence interval
   \item upper The high 95\% confidence interval
 }
+When \code{tidy} is FALSE, returns a \code{list} of \code{htest} objects.
 }
 \description{
 t-test qPCR data

--- a/man/pcr_wilcox.Rd
+++ b/man/pcr_wilcox.Rd
@@ -4,7 +4,7 @@
 \alias{pcr_wilcox}
 \title{Wilcoxon test qPCR data}
 \usage{
-pcr_wilcox(df, group_var, reference_gene, reference_group, ...)
+pcr_wilcox(df, group_var, reference_gene, reference_group, tidy = TRUE, ...)
 }
 \arguments{
 \item{df}{A data.frame of \eqn{C_T} values with genes in the columns and samples
@@ -17,6 +17,9 @@ this variable should equal the number of rows of df}
 
 \item{reference_group}{A character string of the control group in group_var}
 
+\item{tidy}{A \code{logical} whether to return a \code{list} of \code{htest}
+or a tidy \code{data.frame}. Default TRUE.}
+
 \item{...}{Other arguments to \code{\link[stats]{wilcox.test}}}
 }
 \value{
@@ -28,6 +31,8 @@ A data.frame of 5 columns
   \item lower The low 95\% confidence interval
   \item upper The high 95\% confidence interval
 }
+
+When \code{tidy} is FALSE, returns a \code{list} of \code{htest} objects.
 }
 \description{
 Wilcoxon test qPCR data

--- a/tests/testthat/test_testing_fun.R
+++ b/tests/testthat/test_testing_fun.R
@@ -201,3 +201,64 @@ test_that("pcr_test runs the lm to adjust for rna quality", {
 
   expect_equal(res$estimate, unname(ll$coefficients)[-1])
 })
+
+test_that("pcr_test returns lm objects", {
+  fl <- system.file('extdata', 'ct4.csv', package = 'pcr')
+  ct4 <- readr::read_csv(fl)
+
+  # make group variable
+  group <- rep(c('control', 'treatment'), each = 12)
+
+
+  # test using pcr_test and return a list of lm object
+  res <- pcr_test(ct4,
+                  group_var = group,
+                  reference_gene = 'ref',
+                  reference_group = 'control',
+                  test = 'lm',
+                  tidy = FALSE)
+
+  expect_true(is.list(res))
+  expect_equal(names(res), names(ct4)[-1])
+  expect_s3_class(res[[1]], 'lm')
+})
+
+test_that("pcr_test returns htest objects with wilcox test", {
+  fl <- system.file('extdata', 'ct4.csv', package = 'pcr')
+  ct4 <- readr::read_csv(fl)
+
+  # make group variable
+  group <- rep(c('control', 'treatment'), each = 12)
+
+  # test using pcr_test
+  res <- pcr_test(ct4,
+                  group_var = group,
+                  reference_gene = 'ref',
+                  reference_group = 'control',
+                  test = 'wilcox.test',
+                  tidy = FALSE)
+
+  expect_true(is.list(res))
+  expect_equal(names(res), names(ct4)[-1])
+  expect_s3_class(res[[1]], 'htest')
+})
+
+test_that("pcr_test returns htest objects with t.test test", {
+  fl <- system.file('extdata', 'ct4.csv', package = 'pcr')
+  ct4 <- readr::read_csv(fl)
+
+  # make group variable
+  group <- rep(c('control', 'treatment'), each = 12)
+
+  # test using pcr_test
+  res <- pcr_test(ct4,
+                  group_var = group,
+                  reference_gene = 'ref',
+                  reference_group = 'control',
+                  test = 't.test',
+                  tidy = FALSE)
+
+  expect_true(is.list(res))
+  expect_equal(names(res), names(ct4)[-1])
+  expect_s3_class(res[[1]], 'htest')
+})


### PR DESCRIPTION
The current return value of `pcr_test` is a tidy `data.frame`. I added an argument `tidy` with default `TRUE` so it returns the same. When `tidy = FALSE` the return value, is a `list` of the original test object for each gene; `lm` when the required `test = 'lm'` and `htest` when `test = 't.test'` or `test = 'wilcox.test'`. This enables all sort of things to be done to the original test object. Below is an example with calling `anova()`, `residuals()` and `fitted` on the `lm()` object.

``` r
library(pcr)

# load ct values
fl <- system.file('extdata', 'ct4.csv', package = 'pcr')
ct4 <- readr::read_csv(fl)
#> Parsed with column specification:
#> cols(
#>   ref = col_double(),
#>   target = col_double()
#> )

# make group variable
group <- rep(c('control', 'treatment'), each = 12)


# test using pcr_test and return a list of lm object
res <- pcr_test(ct4,
                group_var = group,
                reference_gene = 'ref',
                reference_group = 'control',
                test = 'lm',
                tidy = FALSE)

# call anova on the lm object
anova(res$target)
#> Analysis of Variance Table
#> 
#> Response: x
#>           Df Sum Sq Mean Sq F value    Pr(>F)    
#> group_var  1 2.8139 2.81391  27.643 2.829e-05 ***
#> Residuals 22 2.2395 0.10179                      
#> ---
#> Signif. codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1

# extract residuals
residuals(res$target)
#>            1            2            3            4            5 
#> -0.271708333 -0.234108333 -0.133808333  0.955891667  0.129991667 
#>            6            7            8            9           10 
#> -0.149808333 -0.338808333  0.116791667 -0.279708333 -0.095108333 
#>           11           12           13           14           15 
#>  0.005691667  0.294691667  0.378916667 -0.021883333  0.379316667 
#>           16           17           18           19           20 
#> -0.415883333 -0.294083333 -0.078883333  0.191616667  0.340916667 
#>           21           22           23           24 
#> -0.234983333  0.110616667 -0.174183333 -0.181483333

# extract fitted values
fitted(res$target)
#>        1        2        3        4        5        6        7        8 
#> 3.640408 3.640408 3.640408 3.640408 3.640408 3.640408 3.640408 3.640408 
#>        9       10       11       12       13       14       15       16 
#> 3.640408 3.640408 3.640408 3.640408 2.955583 2.955583 2.955583 2.955583 
#>       17       18       19       20       21       22       23       24 
#> 2.955583 2.955583 2.955583 2.955583 2.955583 2.955583 2.955583 2.955583

# make diagnostic plots
## qq-plot of the residuals
qqnorm(residuals(res$target))
```

![](https://i.imgur.com/Hne5C2U.png)

``` r

## fitted vs residuals
plot(x = fitted(res$target),
     y = residuals(res$target))
```

![](https://i.imgur.com/UMdn5zn.png)
