### PR TITLE
Add the option to use less-than-perfect amplification efficiencies

### DIFF
--- a/R/analyses_fun.R
+++ b/R/analyses_fun.R
@@ -70,7 +70,7 @@
 #'          plot = TRUE)
 #'
 #' @export
-pcr_ddct <- function(df, group_var, reference_gene, reference_group,
+pcr_ddct <- function(df, group_var, reference_gene, reference_group, amplification_efficiency,
                      mode = 'separate_tube', plot = FALSE, ...) {
   # order data.frame and group var
   df <- df[order(group_var),]
@@ -84,6 +84,9 @@ pcr_ddct <- function(df, group_var, reference_gene, reference_group,
   res <- apply(goi,
                MARGIN = 2,
                FUN = function(x) {
+                 # get the name of the column that x points to
+                 col_name = names(goi)[which(goi == x, arr.ind=T)[, "col"]]
+                 
                  if (mode == 'separate_tube') {
                    # calculate the averages
                    x_ave <- .pcr_average(x, group_var)
@@ -116,11 +119,11 @@ pcr_ddct <- function(df, group_var, reference_gene, reference_group,
                  ddct <- .pcr_normalize(dct, group_ref)
 
                  # calculate the relative expression
-                 rel_expr <- .pcr_relative(ddct)
+                 rel_expr <- .pcr_relative(ddct, amplification_efficiency, col_name)
 
                  # calculate the error bars
-                 upper <- .pcr_relative(ddct - error)
-                 lower <- .pcr_relative(ddct + error)
+                 upper <- .pcr_relative(ddct - error, amplification_efficiency, col_name)
+                 lower <- .pcr_relative(ddct + error, amplification_efficiency, col_name)
 
                  # make a data.frame
                  data.frame(

--- a/R/helper_fun.R
+++ b/R/helper_fun.R
@@ -148,9 +148,14 @@
 #' pcr:::.pcr_relative(vec)
 
 .pcr_relative_mod <- function(vec, amp_eff, col_name) {
-  a_e <- amp_eff %>% select(contains(col_name))
-  res <- a_e[1,1] ^ (-vec)
-  return(res)
+  if (amp_eff) {
+      a_e <- amp_eff %>% select(contains(col_name))
+      res <- a_e[1,1] ^ (-vec)
+      return(res)
+  } else {
+      res <- 2 ^ (-vec)
+      return(res)
+  }
 }                  
                    
 #' Calculate R squared

--- a/R/helper_fun.R
+++ b/R/helper_fun.R
@@ -147,11 +147,12 @@
 #' vec <- rnorm(6, 30, 1)
 #' pcr:::.pcr_relative(vec)
 
-.pcr_relative <- function(vec) {
-  res <- 2 ^ (-vec)
+.pcr_relative_mod <- function(vec, amp_eff, col_name) {
+  a_e <- amp_eff %>% select(contains(col_name))
+  res <- a_e[1,1] ^ (-vec)
   return(res)
-}
-
+}                  
+                   
 #' Calculate R squared
 #'
 #' @inheritParams .pcr_average

--- a/R/helper_fun.R
+++ b/R/helper_fun.R
@@ -147,7 +147,7 @@
 #' vec <- rnorm(6, 30, 1)
 #' pcr:::.pcr_relative(vec)
 
-.pcr_relative_mod <- function(vec, amp_eff, col_name) {
+.pcr_relative <- function(vec, amp_eff, col_name) {
   if (amp_eff) {
       a_e <- amp_eff %>% select(contains(col_name))
       res <- a_e[1,1] ^ (-vec)


### PR DESCRIPTION
This PR adds the option to use a table with the amplification efficiencies with the pcr_ddct method, instead of assuming perfect amplification as mentioned in #21 .
The table should be one row with the amplification efficiencies (e.g. 1.89) and the same gene names as column names, that are also used in the dataset to call the main function.

One thing I am not sure about, is if I correctly implemented the optionality, so please review that :)
