### PR TITLE
pcr_rsquared_with_NAs

### DIFF
--- a/R/helper_fun.R
+++ b/R/helper_fun.R
@@ -170,8 +170,7 @@
 .pcr_rsquared <- function(vec, var) {
   if(anyNA(vec)){
     warning(paste0(sum(is.na(vec)),
-                   sep = " ",
-                   "NAs detected. ",
+                   " NAs detected. ",
                    "Ensure samples are still in the dynamic range"))
   }
   res <- cor(vec,

--- a/R/helper_fun.R
+++ b/R/helper_fun.R
@@ -168,8 +168,15 @@
 #' @importFrom stats cor
 
 .pcr_rsquared <- function(vec, var) {
-  res <- cor(vec, log10(var))^2
-  return(res)
+    if(anyNA(vec)){
+      warning(paste0(sum(is.na(vec)), sep = " ",
+                     "NAs detected. Ensure samples are still in dynamic range"))
+      na_indices <- which(is.na(vec))
+      vec <- vec[-na_indices]
+      var <- var[-na_indices]
+    }
+    res <- cor(vec, log10(var))^2
+    return(res)
 }
 
 #' Calculate the intercept of a line

--- a/R/helper_fun.R
+++ b/R/helper_fun.R
@@ -171,11 +171,8 @@
     if(anyNA(vec)){
       warning(paste0(sum(is.na(vec)), sep = " ",
                      "NAs detected. Ensure samples are still in dynamic range"))
-      na_indices <- which(is.na(vec))
-      vec <- vec[-na_indices]
-      var <- var[-na_indices]
     }
-    res <- cor(vec, log10(var))^2
+    res <- cor(vec, log10(var), use = "complete.obs")^2
     return(res)
 }
 

--- a/R/helper_fun.R
+++ b/R/helper_fun.R
@@ -168,12 +168,16 @@
 #' @importFrom stats cor
 
 .pcr_rsquared <- function(vec, var) {
-    if(anyNA(vec)){
-      warning(paste0(sum(is.na(vec)), sep = " ",
-                     "NAs detected. Ensure samples are still in dynamic range"))
-    }
-    res <- cor(vec, log10(var), use = "complete.obs")^2
-    return(res)
+  if(anyNA(vec)){
+    warning(paste0(sum(is.na(vec)),
+                   sep = " ",
+                   "NAs detected. ",
+                   "Ensure samples are still in the dynamic range"))
+  }
+  res <- cor(vec,
+             log10(var),
+             use = "complete.obs")^2
+  return(res)
 }
 
 #' Calculate the intercept of a line


### PR DESCRIPTION
This minor modification to the `pcr_rsquared()` helper function could fix the issue by skipping the missing point(s) of the curve, not affecting curve calculation for the other genes/columns without `NAs`.

The modified function skips any dilution which is paired with `NA` by utilizing the use argument of the `cor()` function. I'd personally like to be informed about any `NAs` in this data. Therefore, it also warns the user that it did.

Best wishes,

Neurarian